### PR TITLE
1.21.5 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 //file:noinspection GroovyAssignabilityCheck
 plugins {
-    id "fabric-loom" version "1.7.+"
+    id "fabric-loom" version "1.10.+"
     id "com.github.johnrengelman.shadow" version "7.1.+"
     id "me.modmuss50.mod-publish-plugin" version "0.5.2"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,20 +3,20 @@ org.gradle.jvmargs = -Xmx1G
 
 # minecraft, mappings and loader dependencies
 # check these on https://modmuss50.me/fabric.html
-minecraft_version = 1.21.4
-quilt_mappings = 3
+minecraft_version = 1.21.5
+quilt_mappings = 6
 loader_version = 0.16.10
-kaleido_config_version = 0.3.1+1.3.2
+kaleido_config_version = 0.3.3+1.3.2
 
 # mod properties
-mod_version = 1.3.6+mc1.21.4
+mod_version = 1.3.6+mc1.21.5
 maven_group = rainglow
 archives_base_name = rainglow
 
 # other dependencies
 java_version = 21
-mod_menu_version = 13.0.0-beta.1
-fabric_api_version = 0.118.5+1.21.4
+mod_menu_version = 14.0.0-rc.2
+fabric_api_version = 0.124.0+1.21.5
 
 pub.should_publish = true
-pub.additional_versions = 1.21.4
+pub.additional_versions = 1.21.5

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/io/ix0rai/rainglow/data/AllayVariantProvider.java
+++ b/src/main/java/io/ix0rai/rainglow/data/AllayVariantProvider.java
@@ -1,6 +1,0 @@
-package io.ix0rai.rainglow.data;
-
-import net.minecraft.entity.VariantProvider;
-
-public interface AllayVariantProvider extends VariantProvider<RainglowColour> {
-}

--- a/src/main/java/io/ix0rai/rainglow/data/EntityVariantProvider.java
+++ b/src/main/java/io/ix0rai/rainglow/data/EntityVariantProvider.java
@@ -1,0 +1,6 @@
+package io.ix0rai.rainglow.data;
+
+public interface EntityVariantProvider {
+    RainglowColour rainglow$getVariant();
+    void rainglow$setVariant(RainglowColour colour);
+}

--- a/src/main/java/io/ix0rai/rainglow/data/GlowSquidVariantProvider.java
+++ b/src/main/java/io/ix0rai/rainglow/data/GlowSquidVariantProvider.java
@@ -1,6 +1,0 @@
-package io.ix0rai.rainglow.data;
-
-import net.minecraft.entity.VariantProvider;
-
-public interface GlowSquidVariantProvider extends VariantProvider<RainglowColour> {
-}

--- a/src/main/java/io/ix0rai/rainglow/data/ParticleHelper.java
+++ b/src/main/java/io/ix0rai/rainglow/data/ParticleHelper.java
@@ -2,8 +2,8 @@ package io.ix0rai.rainglow.data;
 
 import net.minecraft.client.particle.ItemBreakParticle;
 import net.minecraft.client.particle.Particle;
+import net.minecraft.client.render.item.ItemRenderState;
 import net.minecraft.client.world.ClientWorld;
-import net.minecraft.unmapped.C_hvackyip;
 
 /**
  * @author A5ho9999
@@ -11,12 +11,12 @@ import net.minecraft.unmapped.C_hvackyip;
  */
 public class ParticleHelper {
     public static class CustomItemBreakParticle extends ItemBreakParticle {
-        public CustomItemBreakParticle(ClientWorld world, double d, double e, double f, C_hvackyip c_hvackyip) {
-            super(world, d, e, f, c_hvackyip);
+        public CustomItemBreakParticle(ClientWorld world, double d, double e, double f, ItemRenderState itemRenderState) {
+            super(world, d, e, f, itemRenderState);
         }
     }
 
-    public static Particle createItemBreakParticle(ClientWorld world, double d, double e, double f, C_hvackyip c_hvackyip) {
-        return new CustomItemBreakParticle(world, d, e, f, c_hvackyip);
+    public static Particle createItemBreakParticle(ClientWorld world, double d, double e, double f, ItemRenderState itemRenderState) {
+        return new CustomItemBreakParticle(world, d, e, f, itemRenderState);
     }
 }

--- a/src/main/java/io/ix0rai/rainglow/data/RainglowEntity.java
+++ b/src/main/java/io/ix0rai/rainglow/data/RainglowEntity.java
@@ -64,7 +64,8 @@ public enum RainglowEntity {
     }
 
     public RainglowColour readNbt(World world, NbtCompound nbt, RandomGenerator random) {
-        RainglowColour colour = RainglowColour.get(nbt.getString(Rainglow.CUSTOM_NBT_KEY));
+        // TODO: correctly handle optional
+        RainglowColour colour = RainglowColour.get(nbt.getString(Rainglow.CUSTOM_NBT_KEY).get());
 
         if (Rainglow.colourUnloaded(world, this, colour)) {
             colour = Rainglow.generateRandomColour(world, random);

--- a/src/main/java/io/ix0rai/rainglow/data/SlimeVariantProvider.java
+++ b/src/main/java/io/ix0rai/rainglow/data/SlimeVariantProvider.java
@@ -1,6 +1,0 @@
-package io.ix0rai.rainglow.data;
-
-import net.minecraft.entity.VariantProvider;
-
-public interface SlimeVariantProvider extends VariantProvider<RainglowColour> {
-}

--- a/src/main/java/io/ix0rai/rainglow/mixin/AllayEntityMixin.java
+++ b/src/main/java/io/ix0rai/rainglow/mixin/AllayEntityMixin.java
@@ -1,7 +1,7 @@
 package io.ix0rai.rainglow.mixin;
 
 import io.ix0rai.rainglow.Rainglow;
-import io.ix0rai.rainglow.data.AllayVariantProvider;
+import io.ix0rai.rainglow.data.EntityVariantProvider;
 import io.ix0rai.rainglow.data.RainglowColour;
 import io.ix0rai.rainglow.data.RainglowEntity;
 import net.minecraft.entity.Entity;
@@ -17,7 +17,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(AllayEntity.class)
-public abstract class AllayEntityMixin extends Entity implements AllayVariantProvider {
+public abstract class AllayEntityMixin extends Entity implements EntityVariantProvider {
     @Shadow public abstract void writeCustomDataToNbt(NbtCompound nbt);
 
     protected AllayEntityMixin(EntityType<? extends AllayEntity> entityType, World world) {
@@ -33,24 +33,24 @@ public abstract class AllayEntityMixin extends Entity implements AllayVariantPro
 
     @Inject(method = "readCustomDataFromNbt", at = @At("TAIL"))
     public void readCustomDataFromNbt(NbtCompound nbt, CallbackInfo ci) {
-        this.setVariant(RainglowEntity.ALLAY.readNbt(this.getWorld(), nbt, this.random));
+        this.rainglow$setVariant(RainglowEntity.ALLAY.readNbt(this.getWorld(), nbt, this.random));
     }
 
     // triggered when an allay duplicates, to apply the same colour as parent
     @Redirect(method = "duplicate", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;spawnEntity(Lnet/minecraft/entity/Entity;)Z"))
     public boolean spawnWithColour(World instance, Entity entity) {
         RainglowColour colour = Rainglow.getColour(this.getUuid(), this.getWorld(), RainglowEntity.ALLAY);
-        ((AllayVariantProvider) entity).setVariant(colour);
+        ((EntityVariantProvider) entity).rainglow$setVariant(colour);
         return this.getWorld().spawnEntity(entity);
     }
 
     @Override
-    public RainglowColour getVariant() {
+    public RainglowColour rainglow$getVariant() {
         return Rainglow.getColour(this.getUuid(), this.getWorld(), RainglowEntity.ALLAY);
     }
 
     @Override
-    public void setVariant(RainglowColour colour) {
+    public void rainglow$setVariant(RainglowColour colour) {
         Rainglow.setColour(this, colour);
     }
 }

--- a/src/main/java/io/ix0rai/rainglow/mixin/DyeItemMixin.java
+++ b/src/main/java/io/ix0rai/rainglow/mixin/DyeItemMixin.java
@@ -31,7 +31,7 @@ public class DyeItemMixin {
                     && !Rainglow.colourUnloaded(user.getWorld(), entityType, colour)
                     && Rainglow.CONFIG.isEntityEnabled(entityType)
                     && Rainglow.getColour(entity.getUuid(), entity.getWorld(), entityType) != colour) {
-                entity.getWorld().playSoundFromEntity(user, entity, SoundEvents.BLOCK_AMETHYST_CLUSTER_BREAK, SoundCategory.PLAYERS, 5.0f, 1.0f);
+                entity.getWorld().playSoundFromEntity(entity, SoundEvents.BLOCK_AMETHYST_CLUSTER_BREAK, SoundCategory.PLAYERS, 5.0f, 1.0f);
                 if (!user.getWorld().isClient()) {
                     stack.decrement(1);
                 }

--- a/src/main/java/io/ix0rai/rainglow/mixin/GlowSquidEntityMixin.java
+++ b/src/main/java/io/ix0rai/rainglow/mixin/GlowSquidEntityMixin.java
@@ -1,9 +1,9 @@
 package io.ix0rai.rainglow.mixin;
 
 import io.ix0rai.rainglow.Rainglow;
+import io.ix0rai.rainglow.data.EntityVariantProvider;
 import io.ix0rai.rainglow.data.RainglowColour;
 import io.ix0rai.rainglow.data.RainglowEntity;
-import io.ix0rai.rainglow.data.GlowSquidVariantProvider;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.passive.WaterCreatureEntity;
 import net.minecraft.entity.passive.GlowSquidEntity;
@@ -20,7 +20,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(GlowSquidEntity.class)
-public abstract class GlowSquidEntityMixin extends SquidEntity implements GlowSquidVariantProvider {
+public abstract class GlowSquidEntityMixin extends SquidEntity implements EntityVariantProvider {
     protected GlowSquidEntityMixin(EntityType<? extends SquidEntity> entityType, World world) {
         super(entityType, world);
         throw new UnsupportedOperationException();
@@ -34,7 +34,7 @@ public abstract class GlowSquidEntityMixin extends SquidEntity implements GlowSq
 
     @Inject(method = "readCustomDataFromNbt", at = @At("TAIL"))
     public void readCustomDataFromNbt(NbtCompound nbt, CallbackInfo ci) {
-        this.setVariant(RainglowEntity.GLOW_SQUID.readNbt(this.getWorld(), nbt, this.random));
+        this.rainglow$setVariant(RainglowEntity.GLOW_SQUID.readNbt(this.getWorld(), nbt, this.random));
     }
 
     /**
@@ -53,12 +53,12 @@ public abstract class GlowSquidEntityMixin extends SquidEntity implements GlowSq
     }
 
     @Override
-    public RainglowColour getVariant() {
+    public RainglowColour rainglow$getVariant() {
         return Rainglow.getColour(this.getUuid(), this.getWorld(), RainglowEntity.GLOW_SQUID);
     }
 
     @Override
-    public void setVariant(RainglowColour colour) {
+    public void rainglow$setVariant(RainglowColour colour) {
         Rainglow.setColour(this, colour);
     }
 

--- a/src/main/java/io/ix0rai/rainglow/mixin/MobEntityMixin.java
+++ b/src/main/java/io/ix0rai/rainglow/mixin/MobEntityMixin.java
@@ -1,13 +1,13 @@
 package io.ix0rai.rainglow.mixin;
 
 import io.ix0rai.rainglow.Rainglow;
+import io.ix0rai.rainglow.data.EntityVariantProvider;
 import io.ix0rai.rainglow.data.RainglowColour;
 import io.ix0rai.rainglow.data.RainglowEntity;
 import net.minecraft.entity.EntityData;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.SpawnReason;
-import net.minecraft.entity.VariantProvider;
 import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.world.LocalDifficulty;
 import net.minecraft.world.ServerWorldAccess;
@@ -31,7 +31,7 @@ public abstract class MobEntityMixin extends LivingEntity {
         RainglowEntity entity = RainglowEntity.get(this);
         if (entity != null) {
             RainglowColour colour = generateColour(entity);
-            ((VariantProvider<RainglowColour>) this).setVariant(colour);
+            ((EntityVariantProvider) this).rainglow$setVariant(colour);
             cir.setReturnValue(entity.createEntityData(colour));
         }
     }

--- a/src/main/java/io/ix0rai/rainglow/mixin/SlimeEntityMixin.java
+++ b/src/main/java/io/ix0rai/rainglow/mixin/SlimeEntityMixin.java
@@ -1,9 +1,9 @@
 package io.ix0rai.rainglow.mixin;
 
 import io.ix0rai.rainglow.Rainglow;
+import io.ix0rai.rainglow.data.EntityVariantProvider;
 import io.ix0rai.rainglow.data.RainglowColour;
 import io.ix0rai.rainglow.data.RainglowEntity;
-import io.ix0rai.rainglow.data.SlimeVariantProvider;
 import net.minecraft.entity.*;
 import net.minecraft.entity.mob.SlimeEntity;
 import net.minecraft.nbt.NbtCompound;
@@ -19,7 +19,7 @@ import org.spongepowered.asm.mixin.injection.Slice;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(SlimeEntity.class)
-public abstract class SlimeEntityMixin extends Entity implements SlimeVariantProvider {
+public abstract class SlimeEntityMixin extends Entity implements EntityVariantProvider {
     @Shadow
     protected abstract ParticleEffect getParticles();
 
@@ -36,7 +36,7 @@ public abstract class SlimeEntityMixin extends Entity implements SlimeVariantPro
 
     @Inject(method = "readCustomDataFromNbt", at = @At("TAIL"))
     public void readCustomDataFromNbt(NbtCompound nbt, CallbackInfo ci) {
-        this.setVariant(RainglowEntity.SLIME.readNbt(this.getWorld(), nbt, this.random));
+        this.rainglow$setVariant(RainglowEntity.SLIME.readNbt(this.getWorld(), nbt, this.random));
     }
 
     /**
@@ -65,10 +65,10 @@ public abstract class SlimeEntityMixin extends Entity implements SlimeVariantPro
                 //noinspection unchecked
                 thisSlime.convert((EntityType<SlimeEntity>) thisSlime.getType(), new EntityConversionParameters(EntityConversionType.SPLIT_ON_DEATH, false, false, team), SpawnReason.TRIGGERED, (newSlime) -> {
                     newSlime.setSize(newSize, true);
-                    newSlime.refreshPositionAndAngles(thisSlime.getX() + offsetX, thisSlime.getY() + 0.5, thisSlime.getZ() + offsetZ, thisSlime.getRandom().nextFloat() * 360.0F, 0.0F);
+                    newSlime.setPosAndAngles(thisSlime.getX() + offsetX, thisSlime.getY() + 0.5, thisSlime.getZ() + offsetZ, thisSlime.getRandom().nextFloat() * 360.0F, 0.0F);
 
                     // Now that headache is done, finally set the child slime color to match the parent
-                    ((SlimeVariantProvider) newSlime).setVariant(parentColor);
+                    ((EntityVariantProvider) newSlime).rainglow$setVariant(parentColor);
                 });
             }
 
@@ -104,12 +104,12 @@ public abstract class SlimeEntityMixin extends Entity implements SlimeVariantPro
     }
 
     @Override
-    public RainglowColour getVariant() {
+    public RainglowColour rainglow$getVariant() {
         return Rainglow.getColour(this.getUuid(), this.getWorld(), RainglowEntity.SLIME);
     }
 
     @Override
-    public void setVariant(RainglowColour colour) {
+    public void rainglow$setVariant(RainglowColour colour) {
         Rainglow.setColour(this, colour);
     }
 }

--- a/src/main/java/io/ix0rai/rainglow/mixin/client/AllayEntityRendererMixin.java
+++ b/src/main/java/io/ix0rai/rainglow/mixin/client/AllayEntityRendererMixin.java
@@ -2,9 +2,9 @@ package io.ix0rai.rainglow.mixin.client;
 
 import io.ix0rai.rainglow.data.EntityRenderStateTracker;
 import io.ix0rai.rainglow.data.RainglowEntity;
-import net.minecraft.class_9996;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.entity.AllayEntityRenderer;
+import net.minecraft.client.render.entity.state.AllayRenderState;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
@@ -16,8 +16,8 @@ import java.util.UUID;
 
 @Mixin(AllayEntityRenderer.class)
 public class AllayEntityRendererMixin {
-    @Inject(method = "m_vhdjjpxx", at = @At("HEAD"), cancellable = true)
-    public void getTexture(class_9996 state, CallbackInfoReturnable<Identifier> cir) {
+    @Inject(method = "getTexture*", at = @At("HEAD"), cancellable = true)
+    public void getTexture(AllayRenderState state, CallbackInfoReturnable<Identifier> cir) {
         if (state instanceof EntityRenderStateTracker) {
             UUID entityUuid = ((EntityRenderStateTracker) state).rainglow$getEntityUuid();
             if (entityUuid != null) {

--- a/src/main/java/io/ix0rai/rainglow/mixin/client/EntityRenderStateMixin.java
+++ b/src/main/java/io/ix0rai/rainglow/mixin/client/EntityRenderStateMixin.java
@@ -1,14 +1,14 @@
 package io.ix0rai.rainglow.mixin.client;
 
 import io.ix0rai.rainglow.data.EntityRenderStateTracker;
-import net.minecraft.class_10017;
+import net.minecraft.client.render.entity.state.EntityRenderState;
 import net.minecraft.entity.Entity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
 import java.util.UUID;
 
-@Mixin(class_10017.class)
+@Mixin(EntityRenderState.class)
 public class EntityRenderStateMixin implements EntityRenderStateTracker {
     @Unique
     private UUID entityUuid;

--- a/src/main/java/io/ix0rai/rainglow/mixin/client/EntityRendererMixin.java
+++ b/src/main/java/io/ix0rai/rainglow/mixin/client/EntityRendererMixin.java
@@ -1,8 +1,8 @@
 package io.ix0rai.rainglow.mixin.client;
 
 import io.ix0rai.rainglow.data.EntityRenderStateTracker;
-import net.minecraft.class_10017;
 import net.minecraft.client.render.entity.EntityRenderer;
+import net.minecraft.client.render.entity.state.EntityRenderState;
 import net.minecraft.entity.Entity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -10,8 +10,8 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(EntityRenderer.class)
-public class EntityRendererMixin<T extends Entity, S extends class_10017> {
-    @Inject(method = "method_62354", at = @At("HEAD"))
+public class EntityRendererMixin<T extends Entity, S extends EntityRenderState> {
+    @Inject(method = "updateState(Lnet/minecraft/entity/Entity;Lnet/minecraft/client/render/entity/state/EntityRenderState;F)V", at = @At("HEAD"))
     private void updateRenderState(T entity, S state, float f, CallbackInfo ci) {
         if (state instanceof EntityRenderStateTracker) {
             ((EntityRenderStateTracker) state).rainglow$setEntity(entity);

--- a/src/main/java/io/ix0rai/rainglow/mixin/client/GlowSquidEntityRendererMixin.java
+++ b/src/main/java/io/ix0rai/rainglow/mixin/client/GlowSquidEntityRendererMixin.java
@@ -2,9 +2,9 @@ package io.ix0rai.rainglow.mixin.client;
 
 import io.ix0rai.rainglow.data.EntityRenderStateTracker;
 import io.ix0rai.rainglow.data.RainglowEntity;
-import net.minecraft.class_10069;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.entity.GlowSquidEntityRenderer;
+import net.minecraft.client.render.entity.state.SquidRenderState;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
@@ -20,8 +20,8 @@ public class GlowSquidEntityRendererMixin {
      * @reason use the colour from the entity's NBT data for textures
      * @author ix0rai
      */
-    @Inject(method = "m_vhdjjpxx", at = @At("HEAD"), cancellable = true)
-    public void getTexture(class_10069 state, CallbackInfoReturnable<Identifier> cir) {
+    @Inject(method = "getTexture*", at = @At("HEAD"), cancellable = true)
+    public void getTexture(SquidRenderState state, CallbackInfoReturnable<Identifier> cir) {
         if (state instanceof EntityRenderStateTracker) {
             UUID entityUuid = ((EntityRenderStateTracker) state).rainglow$getEntityUuid();
             if (entityUuid != null) {

--- a/src/main/java/io/ix0rai/rainglow/mixin/client/SlimeEntityRendererMixin.java
+++ b/src/main/java/io/ix0rai/rainglow/mixin/client/SlimeEntityRendererMixin.java
@@ -2,9 +2,9 @@ package io.ix0rai.rainglow.mixin.client;
 
 import io.ix0rai.rainglow.data.EntityRenderStateTracker;
 import io.ix0rai.rainglow.data.RainglowEntity;
-import net.minecraft.class_10067;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.entity.SlimeEntityRenderer;
+import net.minecraft.client.render.entity.state.SlimeRenderState;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
@@ -16,8 +16,8 @@ import java.util.UUID;
 
 @Mixin(SlimeEntityRenderer.class)
 public class SlimeEntityRendererMixin {
-    @Inject(method = "m_vhdjjpxx", at = @At("HEAD"), cancellable = true)
-    public void getTexture(class_10067 state, CallbackInfoReturnable<Identifier> cir) {
+    @Inject(method = "getTexture*", at = @At("HEAD"), cancellable = true)
+    public void getTexture(SlimeRenderState state, CallbackInfoReturnable<Identifier> cir) {
         if (state instanceof EntityRenderStateTracker) {
             UUID entityUuid = ((EntityRenderStateTracker) state).rainglow$getEntityUuid();
             if (entityUuid != null) {

--- a/src/main/java/io/ix0rai/rainglow/mixin/client/SlimeOverlayFeatureRendererMixin.java
+++ b/src/main/java/io/ix0rai/rainglow/mixin/client/SlimeOverlayFeatureRendererMixin.java
@@ -2,12 +2,12 @@ package io.ix0rai.rainglow.mixin.client;
 
 import io.ix0rai.rainglow.data.EntityRenderStateTracker;
 import io.ix0rai.rainglow.data.RainglowEntity;
-import net.minecraft.class_10067;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.entity.SlimeEntityRenderer;
 import net.minecraft.client.render.entity.feature.SlimeOverlayFeatureRenderer;
+import net.minecraft.client.render.entity.state.SlimeRenderState;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.util.Identifier;
@@ -27,9 +27,9 @@ public class SlimeOverlayFeatureRendererMixin {
     /**
      * Override the outline texture for slimes, defaults back to normal if null
      */
-    @Redirect(method = "render(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;ILnet/minecraft/class_10067;FF)V",
+    @Redirect(method = "render(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;ILnet/minecraft/client/render/entity/state/SlimeRenderState;FF)V",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/RenderLayer;getOutline(Lnet/minecraft/util/Identifier;)Lnet/minecraft/client/render/RenderLayer;"))
-    private RenderLayer rainglow$getOutline(Identifier defaultTexture, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i, class_10067 state, float f, float g) {
+    private RenderLayer rainglow$getOutline(Identifier defaultTexture, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i, SlimeRenderState state, float f, float g) {
         Identifier overrideTexture = getOverrideTexture(state);
         return overrideTexture != null ? RenderLayer.getOutline(overrideTexture) : RenderLayer.getOutline(SlimeEntityRenderer.TEXTURE);
     }
@@ -37,15 +37,15 @@ public class SlimeOverlayFeatureRendererMixin {
     /**
      * Override the translucent texture for slimes, defaults back to normal if null
      */
-    @Redirect(method = "render(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;ILnet/minecraft/class_10067;FF)V",
+    @Redirect(method = "render(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;ILnet/minecraft/client/render/entity/state/SlimeRenderState;FF)V",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/RenderLayer;getEntityTranslucent(Lnet/minecraft/util/Identifier;)Lnet/minecraft/client/render/RenderLayer;"))
-    private RenderLayer rainglow$getEntityTranslucent(Identifier defaultTexture, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i, class_10067 state, float f, float g) {
+    private RenderLayer rainglow$getEntityTranslucent(Identifier defaultTexture, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i, SlimeRenderState state, float f, float g) {
         Identifier overrideTexture = getOverrideTexture(state);
         return overrideTexture != null ? RenderLayer.getEntityTranslucent(overrideTexture) : RenderLayer.getEntityTranslucent(SlimeEntityRenderer.TEXTURE);
     }
 
     @Unique
-    private Identifier getOverrideTexture(class_10067 state) {
+    private Identifier getOverrideTexture(SlimeRenderState state) {
         if (state instanceof EntityRenderStateTracker) {
             UUID entityUuid = ((EntityRenderStateTracker) state).rainglow$getEntityUuid();
             if (entityUuid != null) {

--- a/src/main/java/io/ix0rai/rainglow/mixin/client/SlimeParticleMixin.java
+++ b/src/main/java/io/ix0rai/rainglow/mixin/client/SlimeParticleMixin.java
@@ -6,12 +6,12 @@ import io.ix0rai.rainglow.data.RainglowEntity;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.particle.ItemBreakParticle;
 import net.minecraft.client.particle.Particle;
+import net.minecraft.client.render.item.ItemRenderState;
 import net.minecraft.client.render.model.json.ModelTransformationMode;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.particle.DefaultParticleType;
-import net.minecraft.unmapped.C_hvackyip;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -25,15 +25,14 @@ public class SlimeParticleMixin {
      */
     @Inject(method = "createParticle*", at = @At("HEAD"), cancellable = true)
     public void createParticle(DefaultParticleType defaultParticleType, ClientWorld clientWorld, double d, double e, double f, double g, double h, double i, CallbackInfoReturnable<Particle> cir) {
-        C_hvackyip itemRenderState = new C_hvackyip();
+        ItemRenderState itemRenderState = new ItemRenderState();
 
         if (!Rainglow.CONFIG.isEntityEnabled(RainglowEntity.SLIME)) {
-            MinecraftClient.getInstance().method_65386().method_65598(itemRenderState, new ItemStack(Items.SLIME_BALL), ModelTransformationMode.GROUND, false, clientWorld, null, 0);
+            MinecraftClient.getInstance().method_65386().update(itemRenderState, new ItemStack(Items.SLIME_BALL), ModelTransformationMode.GROUND, clientWorld, null, 0);
             cir.setReturnValue(ParticleHelper.createItemBreakParticle(clientWorld, d, e, f, itemRenderState));
-        // 99.9d and 100.1d are used to account for floating point errors
-        } else if (h >= 99.9d && h <= 100.1d) {
+        } else if (h >= 99.9d && h <= 100.1d) { // 99.9d and 100.1d are used to account for floating point errors
             ItemStack stack = RainglowEntity.SLIME.getItem((int) g).getDefaultStack();
-            MinecraftClient.getInstance().method_65386().method_65598(itemRenderState, stack, ModelTransformationMode.GROUND, false, clientWorld, null, 0);
+            MinecraftClient.getInstance().method_65386().update(itemRenderState, stack, ModelTransformationMode.GROUND, clientWorld, null, 0);
             cir.setReturnValue(ParticleHelper.createItemBreakParticle(clientWorld, d, e, f, itemRenderState));
         } else {
             cir.setReturnValue(null);

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -40,7 +40,7 @@
     "fabricloader": ">=0.16.7",
     "fabric-resource-loader-v0": "*",
     "fabric-networking-api-v1": "*",
-    "minecraft": "1.21.4"
+    "minecraft": "1.21.5"
   },
 
   "suggests": {
@@ -48,9 +48,6 @@
   },
 
   "custom": {
-    "loom:injected_interfaces": {
-      "net/minecraft/class_5776": ["io/ix0rai/rainglow/data/GlowSquidVariantProvider"]
-    },
     "modmenu": {
       "links": {
         "modmenu.discord": "https://discord.gg/TN9gaXJ6E8",


### PR DESCRIPTION
Updates to 1.21.5

Not much changed in terms of logic, just remapped unmapped stuff and trimmed the fat for the variant provider (since no longer exists in vanilla)

- Updated Dependencies + Loom/Gradle
- Updated the mappings so it's no longer unmapped methods/classes
- Removed the separate Variant Providers and added a single one with get and set 
  - Since variants are data driven now, the VariantProvider from vanilla is gone
  
Not done any bug testing outside for loading a world, spawning & saving/loading